### PR TITLE
Run in foreground

### DIFF
--- a/bin/app-run
+++ b/bin/app-run
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+set -u
+
+export APPSH_HOME=$(cd $(dirname "$0")/.. && pwd)
+
+. $APPSH_HOME/lib/common
+# HEADER END
+
+exec $APPSH_HOME/libexec/app-operate "run" "$@"

--- a/docs/app-run.txt
+++ b/docs/app-run.txt
@@ -1,0 +1,41 @@
+app-start(1)
+===========
+
+NAME
+----
+app-run - Starts an application in the foreground
+
+SYNOPSIS
+--------
+[verse]
+'app-run'
+
+DESCRIPTION
+-----------
+
+Launches an application in the foreground. The application will be controlled by the
+launcher configured for the application, or
+linkman:app-operator-pid[1] if a launcher is not configured.
+A launcher can check for the presence of "APP_FOREGROUND" to determine if it should
+disable input/output streams.
+Arguments may be given to the run command.
+
+ENABLING AND DISABLING APPLICATIONS
+-----------------------------------
+When using 'app-run' an application will run regardless of the enable/disable status.
+
+SEE ALSO
+--------
+
+linkman:app-stop[1],
+linkman:app-start[1],
+linkman:app-enable[1],
+linkman:app-disable[1]
+
+APP.SH
+------
+
+Part of the linkman:app[1] suite.
+
+// vim: set ft=asciidoc:
+

--- a/libexec/app-operator-pid
+++ b/libexec/app-operator-pid
@@ -78,6 +78,28 @@ find_pid_management() {
   esac
 }
 
+command_run() {
+  launcher=`find_launcher`
+  pid_management=`find_pid_management`
+
+  debug "launcher=$launcher"
+  debug "pid_management=$pid_management"
+  debug "pwd=`pwd`"
+
+  case `do_status` in
+    running)
+      echo "The application is already running as $PID."
+      exit 1
+      ;;
+  esac
+
+  export APPSH_HOME
+  export APP_FOREGROUND=1
+  debug "Starting app in foreground..."
+  exec $launcher @*
+  return $?
+}
+
 command_start() {
   launcher=`find_launcher`
   pid_management=`find_pid_management`
@@ -218,7 +240,7 @@ fi
 command="$1"
 
 case "$command" in
-  start|stop|status|restart)
+  run|start|stop|status|restart)
     command_$command
     ret=$?
     exit $ret


### PR DESCRIPTION
Let an app be able to run in foreground.

An app may check for the presence of  APP_FOREGROUND variable so it knows that it should not redirect output.
