### PR TITLE
Make time we wait for TERM to work config option

### DIFF
--- a/docs/app-operator-pid.txt
+++ b/docs/app-operator-pid.txt
@@ -33,6 +33,9 @@ Support configurable signal to send on shutdown::
 Tests for app.pid_management=launcher::
     Missing.
 
+Tests for app.stop_timeout::
+    Missing.
+
 APPMGR
 ------
 

--- a/lib/appmgr/app-operator-pid
+++ b/lib/appmgr/app-operator-pid
@@ -177,10 +177,15 @@ command_stop() {
       ;;
   esac
 
-  echo -n "Sending TERM to $PID, waiting for shutdown"
+  local stop_timeout=$(app-conf get app.stop_timeout)
+  if [[ ! $stop_timeout =~ [0-9] ]]
+  then
+    stop_timeout=10
+  fi
+  echo -n "Sending TERM to $PID, waiting for shutdown for a maximum of $stop_timeout seconds"
   kill -TERM "$PID"
 
-  for ((i=1; i<10; i++))
+  for ((i=1; i<$stop_timeout; i++))
   do
     if [[ $(do_status) != running ]]
     then

--- a/lib/appmgr/app-operator-pid
+++ b/lib/appmgr/app-operator-pid
@@ -177,10 +177,10 @@ command_stop() {
       ;;
   esac
 
-  local stop_timeout=$(app-conf get app.stop_timeout)
+  local stop_timeout=$(app conf get app.stop_timeout)
   if [[ ! $stop_timeout =~ [0-9] ]]
   then
-    stop_timeout=10
+    stop_timeout=600
   fi
   echo -n "Sending TERM to $PID, waiting for shutdown for a maximum of $stop_timeout seconds"
   kill -TERM "$PID"

--- a/lib/appmgr/app-operator-pid
+++ b/lib/appmgr/app-operator-pid
@@ -180,6 +180,7 @@ command_stop() {
   local stop_timeout=$(app conf get app.stop_timeout)
   if [[ ! $stop_timeout =~ [0-9] ]]
   then
+    echo "Got stop timeout from config, but not number? $stop_timeout"
     stop_timeout=600
   fi
   echo -n "Sending TERM to $PID, waiting for shutdown for a maximum of $stop_timeout seconds"

--- a/lib/appmgr/app-resolver-maven
+++ b/lib/appmgr/app-resolver-maven
@@ -45,7 +45,7 @@ get_file() {
 get_http() {
   curl -n -o "$file" "$url" -D curl.tmp
 
-  exit=$(grep "^HTTP/[0-9](\.[0-9])? 200 .*" curl.tmp >/dev/null; echo $?)
+  exit=$(grep -E "^HTTP/[0-9](\.[0-9])? 200 .*" curl.tmp >/dev/null; echo $?)
   head=$(head -n 1 curl.tmp)
   rm -f curl.tmp
   if [ "$exit" != 0 ]

--- a/lib/appmgr/app-resolver-maven
+++ b/lib/appmgr/app-resolver-maven
@@ -45,7 +45,7 @@ get_file() {
 get_http() {
   curl -n -o "$file" "$url" -D curl.tmp
 
-  exit=$(grep "^HTTP/[0-9]\.[0-9] 200 .*" curl.tmp >/dev/null; echo $?)
+  exit=$(grep "^HTTP/[0-9](\.[0-9])? 200 .*" curl.tmp >/dev/null; echo $?)
   head=$(head -n 1 curl.tmp)
   rm -f curl.tmp
   if [ "$exit" != 0 ]


### PR DESCRIPTION
Some of our apps take considerably longer than 10 seconds to shut down,
so lets make it configurable how long we wait for TERM to work before we
move on to full nuclear KILL.

This is modeled on the setting for launch_timeout just above, so should
behave similarly. The default is still 10 seconds.

Added a note in the docs about missing tests for this new config option.