### PR TITLE
Support HTTP/2 in app-resolver-maven

### DIFF
--- a/lib/appmgr/app-resolver-maven
+++ b/lib/appmgr/app-resolver-maven
@@ -45,7 +45,7 @@ get_file() {
 get_http() {
   curl -n -o "$file" "$url" -D curl.tmp
 
-  exit=$(grep "^HTTP/[0-9](\.[0-9])? 200 .*" curl.tmp >/dev/null; echo $?)
+  exit=$(grep -E "^HTTP/[0-9](\.[0-9])? 200 .*" curl.tmp >/dev/null; echo $?)
   head=$(head -n 1 curl.tmp)
   rm -f curl.tmp
   if [ "$exit" != 0 ]

--- a/lib/appmgr/app-resolver-maven
+++ b/lib/appmgr/app-resolver-maven
@@ -45,7 +45,7 @@ get_file() {
 get_http() {
   curl -n -o "$file" "$url" -D curl.tmp
 
-  exit=$(grep "^HTTP/[0-9]\.[0-9] 200 .*" curl.tmp >/dev/null; echo $?)
+  exit=$(grep "^HTTP/[0-9](\.[0-9])? 200 .*" curl.tmp >/dev/null; echo $?)
   head=$(head -n 1 curl.tmp)
   rm -f curl.tmp
   if [ "$exit" != 0 ]


### PR DESCRIPTION
Support HTTP2 responses, i.e. responses that start with HTTP/2 and not HTTP/1.1 in app-resolver-maven